### PR TITLE
feat(assets): Slack Botアイコンをbot専用デザインに更新

### DIFF
--- a/_assets/icon-bot-dark.svg
+++ b/_assets/icon-bot-dark.svg
@@ -1,0 +1,16 @@
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <!-- 背景 -->
+  <rect width="40" height="40" rx="8" fill="#4A154B"/>
+  
+  <!-- 顔 -->
+  <circle cx="20" cy="20" r="12" fill="white" opacity="0.9"/>
+  
+  <!-- 左目 -->
+  <rect x="14" y="16" width="4" height="4" rx="1" fill="#E01E5A"/>
+  
+  <!-- 右目 -->
+  <rect x="22" y="16" width="4" height="4" rx="1" fill="#E01E5A"/>
+  
+  <!-- 口 -->
+  <rect x="16" y="24" width="8" height="2" rx="1" fill="#36C5F0"/>
+</svg>

--- a/_assets/icon-bot.svg
+++ b/_assets/icon-bot.svg
@@ -1,0 +1,16 @@
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <!-- 背景 -->
+  <rect width="40" height="40" rx="8" fill="#4A154B"/>
+  
+  <!-- 顔 -->
+  <circle cx="20" cy="20" r="12" fill="white" opacity="0.9"/>
+  
+  <!-- 左目 -->
+  <rect x="14" y="16" width="4" height="4" rx="1" fill="#E01E5A"/>
+  
+  <!-- 右目 -->
+  <rect x="22" y="16" width="4" height="4" rx="1" fill="#E01E5A"/>
+  
+  <!-- 口 -->
+  <rect x="16" y="24" width="8" height="2" rx="1" fill="#36C5F0"/>
+</svg>

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -12,8 +12,8 @@ description:
   ja_JP: このSlack Botは、SlackからのメッセージをDifyのChatflow/Chatbot/Agentへの入力として受け取ります。app_mentionにくわえ、reactionで動作させることも可能であり、Slackにメッセージを送信する際、スレッドへの投稿もサポートします。
   zh_Hans: 这个 Slack Bot 将从 Slack 接收消息并作为输入传递给 Dify 的 Chatflow/Chatbot/Agent。除了应用提及外，还可以通过反应来触发它，同时支持在发送 Slack 消息时在线程中发布内容。
   pt_BR: Este Slack Bot recebe mensagens do Slack como entrada para o Chatflow/Chatbot/Agent do Dify. Além do app_mention, também é possível operá-lo com reação e, ao enviar mensagens para o Slack, ele também suporta postagens em threads.
-icon: icon.svg
-icon_dark: icon-dark.svg
+icon: icon-bot.svg
+icon_dark: icon-bot-dark.svg
 resource:
   memory: 268435456
   permission:


### PR DESCRIPTION
feat(assets): Slack Botアイコンをbot専用デザインに更新

新しいボットアイコンのSVGファイルを追加し、manifest.yamlでアイコンの参照を更新。
Slackのブランドカラーを使用したロボット風デザインで、ライトテーマとダークテーマの
両方に対応したアイコンを提供する。

- _assets/icon-bot.svg, icon-bot-dark.svgを新規追加
- manifest.yamlのiconパスをgenericなものからbot専用に変更
- 40x40pxのSVGフォーマットでSlackプラットフォームに最適化
