### PR TITLE
feat: Slackボットの入力パラメータを拡張し、イベント情報を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The plugin follows Dify's extension plugin architecture:
 3. **Configuration**: 
    - `manifest.yaml` - Plugin metadata and resource configuration
    - `group/slack-bot2.yaml` - Settings schema and endpoint registration
-   - `endpoints/slack-bot2.yaml` - Endpoint path configuration
+   - `endpoints/slack_bot2.yaml` - Endpoint path configuration
 
 ### Event Processing Flow
 1. Slack sends events to the endpoint (`/uwu/slack-bot2/uwu`)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,8 @@
+# Change Log
+## 0.0.2 - 2025-08-17
+### Added
+- Added `channel`, `thread_ts`, `event_type`, and `reaction` fields to inputs
+
+## 0.0.1 - 2025-08-11
+### Added
+- First Published Version.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ On the "Event Subscriptions" page:
 #### Allow Retry Requests
 - **Optional field** (default: false)
 - Determines whether to allow retry requests from Slack
-- If set to `false`, the system will automatically ignore timeout or duplicate requests
+- If set to `false`, the system will automatically ignore timeout or duplicate requests(Recommended)
 
 #### Target Reactions
 - **Optional field**
@@ -99,3 +99,16 @@ On the "Event Subscriptions" page:
 - **Optional field** (default: false)
 - If set to `true`, replies will be posted in the original message's thread
 - If set to `false`, replies will be posted as new messages in the channel
+
+## Usage
+The bot will respond when you mention it or use a specific emoji to react to a message.
+
+### Input Parameters
+When triggered, the bot receives the following data from the event.
+
+| Parameter | Description | Type |
+|-----------|-------------|------|
+| channel | The ID of the channel where the event happened. | string |
+| thread_ts | The timestamp of the thread. This is present if the event occurred in a thread, allowing the bot to reply in that thread. | string (optional) |
+| event_type | Indicates how the bot was triggered. Can be `app_mention` or `reaction_added`. | string |
+| reaction | The name of the emoji used for the reaction (e.g., `eye`). This is present only for `reaction_added` events. | string (optional) |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ On the "Event Subscriptions" page:
 The bot will respond when you mention it or use a specific emoji to react to a message.
 
 ### Input Parameters
-When triggered, the bot receives the following data from the event.
+When triggered, `sys.query` contains the original Slack message. And the bot receives the following inputs data from the event.
 
 | Parameter | Description | Type |
 |-----------|-------------|------|

--- a/endpoints/slack_bot2.py
+++ b/endpoints/slack_bot2.py
@@ -2,7 +2,7 @@ import json
 import logging
 import traceback
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Optional
 
 from dify_plugin import Endpoint
 from dify_plugin.config.logger_format import plugin_logger_handler
@@ -59,7 +59,14 @@ class SlackBot2Endpoint(Endpoint):
                         event.get("ts") if settings.get("enable_thread_reply") else None
                     )
                     return self._process_dify_request(
-                        message, channel, blocks, thread_ts, settings, files
+                        message=message,
+                        channel=channel,
+                        blocks=blocks,
+                        thread_ts=thread_ts,
+                        settings=settings,
+                        event_type="app_mention",
+                        reaction=None,
+                        files=files,
                     )
                 else:
                     return Response(status=200, response="ok")
@@ -79,7 +86,9 @@ class SlackBot2Endpoint(Endpoint):
                     thread_ts = (
                         message_ts if settings.get("enable_thread_reply") else None
                     )
-                    return self._on_reaction(channel, message_ts, thread_ts, settings)
+                    return self._on_reaction(
+                        channel, message_ts, thread_ts, settings, event.get("reaction")
+                    )
                 else:
                     return Response(status=200, response="ok")
             else:
@@ -93,6 +102,7 @@ class SlackBot2Endpoint(Endpoint):
         message_ts: str,
         thread_ts: str | None,
         settings: Mapping,
+        reaction: str,
     ) -> Response:
         try:
             token = settings.get("bot_token")
@@ -118,7 +128,14 @@ class SlackBot2Endpoint(Endpoint):
                     blocks[0]["elements"][0]["elements"] = []
                 message_text = message.get("text", "")
                 return self._process_dify_request(
-                    message_text, channel, blocks, thread_ts, settings, files
+                    message=message_text,
+                    channel=channel,
+                    blocks=blocks,
+                    thread_ts=thread_ts,
+                    settings=settings,
+                    event_type="reaction_added",
+                    reaction=reaction,
+                    files=files,
                 )
             return Response(status=200, response="ok")
         except SlackApiError as e:
@@ -132,13 +149,20 @@ class SlackBot2Endpoint(Endpoint):
         blocks: list,
         thread_ts: str | None,
         settings: Mapping,
+        event_type: str,
+        reaction: Optional[str] = None,
         files: list | None = None,
     ) -> Response:
         """Process request to Dify and post response to Slack"""
         try:
             token = settings.get("bot_token")
             client = WebClient(token=token)
-            inputs: dict[str, Any] = {}
+            inputs: dict[str, Any] = {
+                "channel": channel,
+                "thread_ts": thread_ts,
+                "event_type": event_type,
+                "reaction": reaction,
+            }
             response = self.session.app.chat.invoke(
                 app_id=settings["app"]["app_id"],
                 query=message,

--- a/endpoints/slack_bot2.py
+++ b/endpoints/slack_bot2.py
@@ -2,7 +2,7 @@ import json
 import logging
 import traceback
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Any
 
 from dify_plugin import Endpoint
 from dify_plugin.config.logger_format import plugin_logger_handler
@@ -150,7 +150,7 @@ class SlackBot2Endpoint(Endpoint):
         thread_ts: str | None,
         settings: Mapping,
         event_type: str,
-        reaction: Optional[str] = None,
+        reaction: str | None = None,
         files: list | None = None,
     ) -> Response:
         """Process request to Dify and post response to Slack"""

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 type: plugin
 author: takada-at
 name: slack-bot2

--- a/tests/test_slack_bot2_endpoint.py
+++ b/tests/test_slack_bot2_endpoint.py
@@ -174,7 +174,12 @@ class TestSlackBot2Endpoint:
         endpoint.session.app.chat.invoke.assert_called_once_with(
             app_id="test-app-id",
             query="Hello bot!",
-            inputs={},
+            inputs={
+                "channel": "C123456",
+                "thread_ts": None,
+                "event_type": "app_mention",
+                "reaction": None,
+            },
             response_mode="blocking",
         )
         mock_webclient.chat_postMessage.assert_called_once()
@@ -253,7 +258,12 @@ class TestSlackBot2Endpoint:
         endpoint.session.app.chat.invoke.assert_called_once_with(
             app_id="test-app-id",
             query="Hello!",
-            inputs={},
+            inputs={
+                "channel": "C123456",
+                "thread_ts": None,
+                "event_type": "reaction_added",
+                "reaction": "thumbsup",
+            },
             response_mode="blocking",
         )
 
@@ -341,7 +351,7 @@ class TestSlackBot2Endpoint:
 
         blocks = [{"text": {"text": "original"}}]
         response = endpoint._process_dify_request(
-            "test message", "C123456", blocks, None, basic_settings
+            "test message", "C123456", blocks, None, basic_settings, "app_mention"
         )
 
         assert response.status_code == 200
@@ -363,7 +373,12 @@ class TestSlackBot2Endpoint:
 
         blocks = [{"text": {"text": "original"}}]
         endpoint._process_dify_request(
-            "test", "C123456", blocks, "1234567890.123456", basic_settings, []
+            "test",
+            "C123456",
+            blocks,
+            "1234567890.123456",
+            basic_settings,
+            "app_mention",
         )
 
         call_args = mock_webclient.chat_postMessage.call_args[1]
@@ -381,7 +396,7 @@ class TestSlackBot2Endpoint:
 
         blocks: list[dict[str, Any]] = [{"elements": [{"elements": []}]}]
         response = endpoint._process_dify_request(
-            "test", "C123456", blocks, None, basic_settings, []
+            "test", "C123456", blocks, None, basic_settings, "app_mention"
         )
 
         assert response.status_code == 200
@@ -402,7 +417,7 @@ class TestSlackBot2Endpoint:
         endpoint.session.app.chat.invoke.return_value = {"answer": "Test response"}
 
         response = endpoint._process_dify_request(
-            "test", "C123456", [], None, basic_settings, []
+            "test", "C123456", [], None, basic_settings, "app_mention"
         )
         assert response.status_code == 200
 
@@ -416,7 +431,7 @@ class TestSlackBot2Endpoint:
         endpoint.session.app.chat.invoke.side_effect = Exception("Dify API Error")
 
         response = endpoint._process_dify_request(
-            "test", "C123456", [], None, basic_settings, []
+            "test", "C123456", [], None, basic_settings, "app_mention"
         )
 
         assert response.status_code == 200
@@ -437,7 +452,7 @@ class TestSlackBot2Endpoint:
         }
 
         response = endpoint._process_dify_request(
-            "test", "C123456", [], None, basic_settings, []
+            "test", "C123456", [], None, basic_settings, "app_mention"
         )
 
         assert response.status_code == 200
@@ -563,7 +578,12 @@ class TestSlackBot2Endpoint:
         assert response.status_code == 200
         endpoint.session.app.chat.invoke.assert_called_once()
         call_args = endpoint.session.app.chat.invoke.call_args[1]
-        assert call_args["inputs"] == {}
+        assert call_args["inputs"] == {
+            "channel": "C123456",
+            "thread_ts": None,
+            "event_type": "app_mention",
+            "reaction": None,
+        }
 
     @patch.object(slack_bot2_module, "WebClient")
     def test_invoke_app_mention_with_files_disabled(
@@ -589,7 +609,12 @@ class TestSlackBot2Endpoint:
         assert response.status_code == 200
         endpoint.session.app.chat.invoke.assert_called_once()
         call_args = endpoint.session.app.chat.invoke.call_args[1]
-        assert call_args["inputs"] == {}
+        assert call_args["inputs"] == {
+            "channel": "C123456",
+            "thread_ts": None,
+            "event_type": "app_mention",
+            "reaction": None,
+        }
 
     @patch.object(slack_bot2_module, "WebClient")
     @patch("requests.get")
@@ -627,4 +652,9 @@ class TestSlackBot2Endpoint:
         assert response.status_code == 200
         endpoint.session.app.chat.invoke.assert_called_once()
         call_args = endpoint.session.app.chat.invoke.call_args[1]
-        assert call_args["inputs"] == {}
+        assert call_args["inputs"] == {
+            "channel": "C123456",
+            "thread_ts": None,
+            "event_type": "app_mention",
+            "reaction": None,
+        }


### PR DESCRIPTION
- `channel`, `thread_ts`, `event_type`, `reaction`フィールドを入力パラメータに追加
- READMEにUsageセクションと入力パラメータの説明表を追加
- Allow Retry Requestsの説明文を改善（Recommendedを明記）
- バージョンを0.0.2に更新
- 変更履歴をChangeLog.mdに記録

この変更により、Slackボットがより詳細なイベント情報を受け取れるようになり、
開発者がボットの動作をより柔軟に制御できるようになります。