### PR TITLE
v0.0.2 fixed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,10 @@
 # Change Log
 ## 0.0.2 - 2025-08-17
 ### Added
-- Added `channel`, `thread_ts`, `event_type`, and `reaction` fields to inputs
+- Added `channel`, `message_ts`, `event_type`, and `reaction` fields to inputs
+
+### Fixed
+- Fixed an issue where the original message for reactions wasn't being properly retrieved
 
 ## 0.0.1 - 2025-08-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,6 +109,6 @@ When triggered, `sys.query` contains the original Slack message. And the bot rec
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | channel | The ID of the channel where the event happened. | string |
-| thread_ts | The timestamp of the thread. This is present if the event occurred in a thread, allowing the bot to reply in that thread. | string (optional) |
+| message_ts | The timestamp of the message. | string (optional) |
 | event_type | Indicates how the bot was triggered. Can be `app_mention` or `reaction_added`. | string |
 | reaction | The name of the emoji used for the reaction (e.g., `eye`). This is present only for `reaction_added` events. | string (optional) |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,6 @@ When triggered, `sys.query` contains the original Slack message. And the bot rec
 | Parameter | Description | Type |
 |-----------|-------------|------|
 | channel | The ID of the channel where the event happened. | string |
-| message_ts | The timestamp of the message. | string (optional) |
+| message_ts | The timestamp of the message. | string |
 | event_type | Indicates how the bot was triggered. Can be `app_mention` or `reaction_added`. | string |
 | reaction | The name of the emoji used for the reaction (e.g., `eye`). This is present only for `reaction_added` events. | string (optional) |

--- a/endpoints/slack_bot2.py
+++ b/endpoints/slack_bot2.py
@@ -117,7 +117,6 @@ class SlackBot2Endpoint(Endpoint):
             # thread message
             return client.conversations_replies(
                 channel=channel,
-                oldest=message_ts,
                 ts=message_ts,
                 inclusive=True,
                 limit=1,

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -38,7 +38,7 @@ plugins:
   endpoints:
     - group/slack-bot2.yaml
 meta:
-  version: 0.0.1
+  version: 0.0.2
   arch:
     - amd64
     - arm64

--- a/tests/test_slack_bot2_endpoint.py
+++ b/tests/test_slack_bot2_endpoint.py
@@ -176,7 +176,7 @@ class TestSlackBot2Endpoint:
             query="Hello bot!",
             inputs={
                 "channel": "C123456",
-                "thread_ts": None,
+                "message_ts": "1234567890.123456",
                 "event_type": "app_mention",
                 "reaction": None,
             },
@@ -239,6 +239,9 @@ class TestSlackBot2Endpoint:
         mock_webclient = Mock()
         mock_webclient_class.return_value = mock_webclient
         mock_webclient.chat_postMessage.return_value = {"ok": True}
+        mock_webclient.chat_getPermalink.return_value = {
+            "permalink": "https://slack.com/archives/C123456/p1234567890123456"
+        }
         mock_webclient.conversations_history.return_value = {
             "messages": [
                 {
@@ -260,7 +263,7 @@ class TestSlackBot2Endpoint:
             query="Hello!",
             inputs={
                 "channel": "C123456",
-                "thread_ts": None,
+                "message_ts": "1234567890.123456",
                 "event_type": "reaction_added",
                 "reaction": "thumbsup",
             },
@@ -365,6 +368,7 @@ class TestSlackBot2Endpoint:
     def test_process_dify_request_with_thread_ts(
         self, mock_webclient_class: Any, endpoint: Any, basic_settings: Any
     ) -> None:
+        basic_settings["enable_thread_reply"] = True
         mock_webclient = Mock()
         mock_webclient_class.return_value = mock_webclient
         mock_webclient.chat_postMessage.return_value = {"ok": True}
@@ -580,7 +584,7 @@ class TestSlackBot2Endpoint:
         call_args = endpoint.session.app.chat.invoke.call_args[1]
         assert call_args["inputs"] == {
             "channel": "C123456",
-            "thread_ts": None,
+            "message_ts": "1234567890.123456",
             "event_type": "app_mention",
             "reaction": None,
         }
@@ -611,7 +615,7 @@ class TestSlackBot2Endpoint:
         call_args = endpoint.session.app.chat.invoke.call_args[1]
         assert call_args["inputs"] == {
             "channel": "C123456",
-            "thread_ts": None,
+            "message_ts": "1234567890.123456",
             "event_type": "app_mention",
             "reaction": None,
         }
@@ -654,7 +658,7 @@ class TestSlackBot2Endpoint:
         call_args = endpoint.session.app.chat.invoke.call_args[1]
         assert call_args["inputs"] == {
             "channel": "C123456",
-            "thread_ts": None,
+            "message_ts": "1234567890.123456",
             "event_type": "app_mention",
             "reaction": None,
         }


### PR DESCRIPTION
fix: リアクション時のメッセージ取得処理を修正

- thread_tsをmessage_tsに変更してメッセージタイムスタンプを正確に管理
- リアクション追加時に元メッセージが適切に取得されない問題を修正
- パラメータの説明をREADMEで更新し、実装との整合性を確保
- テストコードでpermalinkのモック処理を追加

影響範囲: 
- Slackボットのリアクション機能の動作改善
- APIパラメータの名称変更（後方互換性に注意）
